### PR TITLE
remove explicit background color from mail view to support dark mode

### DIFF
--- a/Mail/ContentView.swift
+++ b/Mail/ContentView.swift
@@ -98,7 +98,6 @@ struct MessageView: View {
         }
         .padding()
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .background(Color.white)
     }
 }
 


### PR DESCRIPTION
Great example, Jordan! I've been looking around for a demo app which brings all of this under one roof.

One of the interesting things about this is we _still_ don't have environment based colors for Swift UI, `UIColor.systemBackground` as an example. One good alternative could the the following: 

```swift
struct ContentView: View {
@Environment(\.colorScheme) var colorScheme
    var body: some View {
         Text("")
        .background(colorScheme == .dark ? Color.black : Color.white)
    }
}
```

I noticed something when running this in dark mode:

<img width="1012" alt="Screen Shot 2020-07-05 at 4 11 06 PM" src="https://user-images.githubusercontent.com/7704414/86543389-37b5d480-bedb-11ea-8803-bdee56236536.png">

I guess letting the system determine the background color will produce the vanilla presentation.

<img width="1012" alt="Screen Shot 2020-07-05 at 4 18 44 PM" src="https://user-images.githubusercontent.com/7704414/86543486-4e106000-bedc-11ea-8948-1b0eb6fdeb11.png">
<img width="1012" alt="Screen Shot 2020-07-05 at 4 19 19 PM" src="https://user-images.githubusercontent.com/7704414/86543488-4ea8f680-bedc-11ea-8ff2-32ee95a153b9.png">
